### PR TITLE
Encoding twice

### DIFF
--- a/index.php
+++ b/index.php
@@ -535,10 +535,11 @@ if(!empty($_GET['url'])){
 	if(idn_to_ascii($parts['host']) == ''){
 		$parts['host'] = utf8_encode($parts['host']);
 	}
-	
+	/*
 	if(isset($_GET['encoding']) && $_GET['encoding'] == 'base64'){
 		ob_start('custom_base64');
 	}
+	*/
 	
 	if(!isset($parts['scheme'])){
 		header('HTTP/1.0 404 Not Found');


### PR DESCRIPTION
I was banging my head against the wall as to why your site was working but not ours. Then I noticed that the first few characters are always the same ('ZG') instead of ('/9'). And turns out the PHP encodes twice base64. Now I don't know if the change above breaks anything else.
