### PR TITLE
Docker: Shallow clone repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN groupadd nginx \
     && useradd -r -g nginx -s /sbin/nologin -c "Nginx web server" nginx
 
 # Clone the repository
-RUN git clone --recurse-submodules https://github.com/weserv/images.git /var/www/imagesweserv
+RUN git clone --depth=1 --recurse-submodules --shallow-submodules https://github.com/weserv/images.git /var/www/imagesweserv
 
 WORKDIR /var/www/imagesweserv/build
 


### PR DESCRIPTION
This reduces the final repo size by 20MB by not cloning the entire git history. In the future the saving should get bigger.

```
docker images | grep weserv
weserver-after                              latest              28890e4580b6        30 seconds ago      1.2GB
weserver-before                             latest              e205949007a7        2 minutes ago       1.22GB
```