### PR TITLE
docker multistage build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@ With the magical help of [libvips](https://github.com/libvips/libvips) and the P
 - Load a given page (`&page=`, for PDF, TIFF and multi-size ICO files).
 - Support for non-standard ports ([#10](https://github.com/weserv/images/issues/10)).
 - A privacy policy. See [Privacy-Policy.md](Privacy-Policy.md).
-- A Docker image for easier deployment. See the [Docker installation instructions](DOCKER.md).
+- A Docker image for easier deployment. See the [Docker installation instructions](docker/README.md).
 
 ### Changed
 - Dropped [Intervention Image](http://image.intervention.io/) in favor of [php-vips](https://github.com/libvips/php-vips) because resizing an image with [libvips](https://github.com/libvips/libvips) is typically 4x-5x faster than using the quickest ImageMagick.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See our [wiki documentation](https://github.com/weserv/images/wiki) or
 ## Docker deployment
 
 For information on Docker deployment, please read the 
-[Docker installation instructions](DOCKER.md).
+[Docker installation instructions](docker/README.md).
 
 ## Submitting Bugs and Suggestions
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM centos:8 as builder
 
 LABEL maintainer="Kleis Auke Wolthuizen <info@kleisauke.nl>"
 
@@ -79,6 +79,24 @@ RUN cmake3 .. \
     && make -j$(nproc) \
     && ldconfig
 
+# from https://myheutagogy.com/2020/04/28/minimizing-the-size-of-docker-images-using-multi-stage-builds/
+# https://web.archive.org/web/20201031151931/https://myheutagogy.com/2020/04/28/minimizing-the-size-of-docker-images-using-multi-stage-builds/
+RUN ldd /usr/sbin/nginx | cut -d" " -f3 | xargs tar --dereference --absolute-names -cf libs.tar
+
+######################
+FROM builder as runner
+
+# Copy nginx to the appropriate location
+COPY --from=builder /usr/sbin/nginx /usr/sbin/nginx
+
+# Copy nginx configuration to the appropriate location
+COPY --from=builder /var/www/imagesweserv/ngx_conf/*.conf /etc/nginx/
+
+# Copy linked libs
+COPY --from=builder /var/www/imagesweserv/build/libs.tar /
+RUN tar --absolute-names -xf libs.tar \
+    && rm *.tar
+
 WORKDIR /var/www/imagesweserv
 
 # Ensure nginx directories exist
@@ -89,9 +107,7 @@ RUN mkdir -p -m 700 /var/lib/nginx \
     && mkdir -p -m 755 /usr/lib64/nginx/modules \
     # Forward request and error logs to docker log collector
     && ln -sf /dev/stdout /var/log/nginx/weserv-access.log \
-    && ln -sf /dev/stderr /var/log/nginx/weserv-error.log \
-    # Copy nginx configuration to the appropriate location
-    && cp /var/www/imagesweserv/ngx_conf/*.conf /etc/nginx
+    && ln -sf /dev/stderr /var/log/nginx/weserv-error.log
 
 EXPOSE 80
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,19 @@
 
 This document describes how to use images.weserv.nl with Docker.
 
-## Installation
+## Hosted image on [github packages](https://github.com/orgs/weserv/packages/container/package/images)
+
+1. Pull and run `ghcr.io/weserv/images` container
+
+    ```bash
+    docker run -d -p 8000:80 --shm-size=1gb --name=imagesweserv ghcr.io/weserv/images:5.x
+    ```
+
+2. Go to http://localhost:8000/?url=images.weserv.nl/lichtenstein.jpg&w=300&h=300
+
+3. Enjoy :-)
+
+## Manual installation
 
 1. Build/run containers
 


### PR DESCRIPTION
This PR make a multistage build, to only keep the compiled nginx in the final image.

> [@kleisauke]  Keep in mind that just copying the library dependencies and executables via a multi-stage build won't work with DNF (CentOS/RHEL/Fedora default package manager), so I'm a bit reluctant for such an approach.

Using `ldd` and `tar`, I managed to get it working fine.

I also took the liberty to update the `docker/README.md` file to document the availability of the image on the github registry.

_Closes #204_ 